### PR TITLE
Add members intent

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,8 @@ from access_data import time_read, time_save
 from discord.ext import commands
 
 update_time_delta = timedelta(hours=6, minutes=0)
-client = commands.Bot(command_prefix='!')
+intents = discord.Intents(messages=True, guilds=True, members=True)
+client = commands.Bot(command_prefix='!', intents=intents)
 table_init()
 
 def check_int(s):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-discord.py>=1.3.2
+discord.py>=1.5
 aiohttp>=3.6.2
 Flask>=1.1.2


### PR DESCRIPTION
`scoreboard` uses guild.get_members frequestly, which demands the Member priviliged intent.
Read https://discordpy.readthedocs.io/en/latest/intents.html for more informations.